### PR TITLE
Feat/ 패스&쿼리 파라미터 관리 훅 구현, 즐겨찾기 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Search from '@/pages/Search';
 import Signup from '@/pages/Signup';
 import Login from '@/pages/Login';
 import { AuthContextProvider } from '@/context/AuthContext';
+import Favorite from '@/pages/Favorite';
 
 const router = createBrowserRouter([
   {
@@ -17,6 +18,7 @@ const router = createBrowserRouter([
       { path: 'movie', element: <Home /> },
       { path: 'movie/:movieId', element: <Detail /> },
       { path: 'search', element: <Search /> },
+      { path: 'favorite', element: <Favorite /> },
       { path: 'login', element: <Login /> },
       { path: 'signup', element: <Signup /> },
     ],

--- a/src/api/actor.ts
+++ b/src/api/actor.ts
@@ -3,7 +3,7 @@ import { baseSearchParam } from '@/types/movie';
 import { MovieCredit } from '@/types/actor';
 
 /** 영화 크레딧 정보 요청 */
-export const fetchCredit = async (movieId: string, queryParams: baseSearchParam) => {
+export const fetchCredit = async (movieId: number, queryParams: baseSearchParam) => {
   const { data } = await axiosInstance<MovieCredit>({
     url: `/movie/${movieId}/credits`,
     method: 'get',

--- a/src/api/favorite.ts
+++ b/src/api/favorite.ts
@@ -1,0 +1,33 @@
+import { supabase } from '@/lib/supabaseClient';
+import { FavoriteData, FavoriteSearchParams } from '@/types/favorite';
+
+// 영화 즐겨찾기 조회
+export const fetchFavorites = async () => {
+  const { data, error } = await supabase.from('Favorites').select('*');
+  if (error) throw error;
+  return data;
+};
+
+// 즐겨찾기 추가
+export const addFavorite = async (favoriteData: FavoriteData) => {
+  const { data, error } = await supabase.from('Favorites').insert([favoriteData]);
+
+  if (error) throw error;
+  return data;
+};
+
+// 즐겨찾기 삭제
+export const deleteFavorite = async ({ movieId, userId }: FavoriteSearchParams) => {
+  const { data, error } = await supabase.from('Favorites').delete().eq('movie_id', movieId).eq('user_id', userId);
+
+  if (error) throw error;
+  return data;
+};
+
+// 특정 영화별 사용자 즐겨찾기에 추가된 리스트 조회
+export const fetchFavoritesByMovie = async ({ movieId, userId }: FavoriteSearchParams) => {
+  const { data, error } = await supabase.from('Favorites').select('*').eq('movie_id', movieId).eq('user_id', userId);
+
+  if (error) throw error;
+  return data;
+};

--- a/src/api/movie.ts
+++ b/src/api/movie.ts
@@ -60,7 +60,7 @@ export const fetchKeywordFilteredMovies = async (queryParams: keywordSearchParam
 };
 
 /** 비슷한 영화 요청 */
-export const fetchSimilarMovies = async (movieId: string, queryParams: baseSearchParam) => {
+export const fetchSimilarMovies = async (movieId: number, queryParams: baseSearchParam) => {
   const { data } = await axiosInstance<MovieResponse>({
     url: `/movie/${movieId}/similar`,
     method: 'get',
@@ -70,7 +70,7 @@ export const fetchSimilarMovies = async (movieId: string, queryParams: baseSearc
 };
 
 /** 영화 세부정보 요청 */
-export const fetchMovieDetail = async (movieId: string, queryParams: baseSearchParam) =>
+export const fetchMovieDetail = async (movieId: number, queryParams: baseSearchParam) =>
   axiosInstance<MovieDetail>({
     url: `/movie/${movieId}`,
     method: 'get',

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -33,6 +33,14 @@ const Layout = () => {
                   <button type="button" onClick={onLogout}>
                     로그아웃
                   </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      navigate('/favorite');
+                    }}
+                  >
+                    찜목록
+                  </button>
                 </>
               ) : (
                 <>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -7,10 +7,10 @@ const SearchBar = () => {
   const { pathname } = useLocation();
   const isSearchPage = pathname.includes('search');
 
-  const { getSearchParam, updateSearchParams } = useUrlParams();
-  const searchKeyword = getSearchParam('query');
+  const { useStringQueryState } = useUrlParams();
+  const [queryParam, setQueryParam] = useStringQueryState('query');
 
-  const [keyword, setKeyword] = useState(searchKeyword || '');
+  const [keyword, setKeyword] = useState(queryParam);
   const debouncedKeyword = useDebounce(keyword, 500);
 
   const handleChange = (e: { target: { value: SetStateAction<string> } }) => {
@@ -18,7 +18,7 @@ const SearchBar = () => {
   };
 
   useEffect(() => {
-    updateSearchParams({ query: debouncedKeyword });
+    setQueryParam(debouncedKeyword);
   }, [debouncedKeyword]);
 
   return (

--- a/src/hooks/query/useActor.ts
+++ b/src/hooks/query/useActor.ts
@@ -3,7 +3,7 @@ import { baseSearchParam } from '@/types/movie';
 import { fetchCredit } from '@/api/actor';
 
 /** 영화 크레딧 정보 요청 */
-export const useGetCreditQuery = (movieId: string, queryParams: baseSearchParam) =>
+export const useGetCreditQuery = (movieId: number, queryParams: baseSearchParam) =>
   useQuery({
     queryFn: () => fetchCredit(movieId, queryParams),
     queryKey: ActorQueryKeys.getMany('credits', queryParams),

--- a/src/hooks/query/useFavorite.ts
+++ b/src/hooks/query/useFavorite.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { addFavorite, deleteFavorite, fetchFavorites, fetchFavoritesByMovie } from '@/api/favorite';
+
+/** 즐겨찾기 조회  */
+export const useGetFavoriteQuery = () =>
+  useQuery({
+    queryFn: fetchFavorites,
+    queryKey: FavoriteQuery.all,
+  });
+
+/**  특정 영화별 사용자 즐겨찾기에 추가된 리스트 조회 */
+export const useGetFavoriteByMovieQuery = (movieId: number, userId: string) =>
+  useQuery({
+    queryFn: () => fetchFavoritesByMovie({ movieId, userId }),
+    queryKey: FavoriteQuery.all,
+    enabled: !!movieId && !!userId,
+  });
+
+/** 즐겨찾기 추가 */
+export const useAddFavoriteQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: addFavorite,
+    onSuccess: () => {
+      alert('찜 추가 완료!');
+      queryClient.invalidateQueries({ queryKey: FavoriteQuery.all });
+    },
+    onError: (error) => {
+      console.error('error', error);
+    },
+  });
+};
+
+/** 즐겨찾기 삭제  */
+export const useDeleteFavoriteQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteFavorite,
+    onSuccess: () => {
+      alert('찜 삭제 완료!');
+      queryClient.invalidateQueries({ queryKey: FavoriteQuery.all });
+    },
+    onError: (error) => {
+      console.error('error', error);
+    },
+  });
+};
+
+export const FavoriteQuery = {
+  all: ['favorite'],
+};

--- a/src/hooks/query/useMovie.ts
+++ b/src/hooks/query/useMovie.ts
@@ -48,14 +48,14 @@ export const useKeywordSearchMoviesQuery = (queryParams: keywordSearchParam, isF
   });
 
 /** 비슷한 영화 요청 */
-export const useGetSimilarMovieQuery = (movieId: string, queryParams: baseSearchParam) =>
+export const useGetSimilarMovieQuery = (movieId: number, queryParams: baseSearchParam) =>
   useQuery({
     queryFn: () => fetchSimilarMovies(movieId, queryParams),
     queryKey: MoviesQuery.getMany('similarMovie', movieId),
   });
 
 /** 영화 세부정보 요청 */
-export const useGetDetailMovieQuery = (movieId: string, queryParams: baseSearchParam) =>
+export const useGetDetailMovieQuery = (movieId: number, queryParams: baseSearchParam) =>
   useQuery({
     queryFn: () => fetchMovieDetail(movieId, queryParams),
     queryKey: MoviesQuery.getOne(movieId),
@@ -69,5 +69,5 @@ export const MoviesQuery = {
     getCategory,
     JSON.stringify(queryParams),
   ],
-  getOne: (id: string) => [...MoviesQuery.all, 'getOne', id],
+  getOne: (id: number) => [...MoviesQuery.all, 'getOne', id],
 };

--- a/src/hooks/usePathParams.ts
+++ b/src/hooks/usePathParams.ts
@@ -1,12 +1,44 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const usePathParams = () => {
   const navigate = useNavigate();
+  const params = useParams();
 
+  /** 경로와 패스파라미터 업데이트 */
   const updatePathParam = (path: string, pathParams: string | number) => {
     navigate(`${path}/${pathParams}`);
   };
-  return { updatePathParam };
+
+  /** 문자열 타입의 패스 파라미터를 상태처럼 사용하는 훅 */
+  const useStringPathState = (paramName: string, defaultValue: string = '') => {
+    const currentValue = (params[paramName] as unknown as string) || defaultValue; // 패스파라미터 조회(문자로)
+
+    const setValue = (newValue: string) => {
+      const newPath = window.location.pathname.replace(new RegExp(`/${params[paramName]}(?=/|$)`), `/${newValue}`);
+      navigate(newPath);
+    };
+
+    return [currentValue, setValue] as const;
+  };
+
+  /** 숫자 타입의 패스 파라미터를 상태처럼 사용하는 훅 */
+  const useNumberPathState = (paramName: string, defaultValue: number = 0) => {
+    const paramValue = params[paramName];
+    const currentValue = paramValue ? Number(paramValue) : defaultValue; // 패스파라미터 조회(숫자로)
+
+    const setValue = (newValue: number) => {
+      const newPath = window.location.pathname.replace(new RegExp(`/${params[paramName]}(?=/|$)`), `/${newValue}`);
+      navigate(newPath);
+    };
+
+    return [currentValue, setValue] as const;
+  };
+
+  return {
+    updatePathParam,
+    useStringPathState,
+    useNumberPathState,
+  };
 };
 
 export default usePathParams;

--- a/src/hooks/useUrlParams.ts
+++ b/src/hooks/useUrlParams.ts
@@ -22,7 +22,33 @@ const useUrlParams = () => {
     });
   };
 
-  return { getSearchParam, updateSearchParams };
+  /** 문자열 타입의 URL 쿼리 파라미터를 상태처럼 사용하는 훅 */
+  const useStringQueryState = (key: string, defaultValue: string = '') => {
+    const currentValue = getSearchParam(key) || defaultValue; // 쿼리 파라미터 조회(문자로)
+
+    const setValue = (newValue: string) => {
+      updateSearchParams({ [key]: newValue });
+    };
+
+    return [currentValue, setValue] as const;
+  };
+
+  /** 숫자 타입의 URL 쿼리 파라미터를 상태처럼 사용하는 훅 */
+  const useNumberQueryState = (key: string, defaultValue: number = 0) => {
+    const paramValue = getSearchParam(key);
+    const currentValue = paramValue ? Number(paramValue) : defaultValue; // 쿼리 파라미터 조회(숫자로)
+
+    const setValue = (newValue: number) => {
+      updateSearchParams({ [key]: String(newValue) });
+    };
+
+    return [currentValue, setValue] as const;
+  };
+
+  return {
+    useStringQueryState,
+    useNumberQueryState,
+  };
 };
 
 export default useUrlParams;

--- a/src/pages/Detail/components/DetailHeader.tsx
+++ b/src/pages/Detail/components/DetailHeader.tsx
@@ -15,7 +15,7 @@ const DetailHeader = ({ movieId }: { movieId: number }) => {
   const addFavorite = useAddFavoriteQuery();
   const deleteCommnet = useDeleteFavoriteQuery();
 
-  const { data: favorites } = useGetFavoriteByMovieQuery(Number(movieId!), userId!);
+  const { data: favorites } = useGetFavoriteByMovieQuery(movieId!, userId!);
   const isFavoriteAdded = !!favorites?.length;
 
   const handleAddFavorite = () => {

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -3,8 +3,7 @@ import { TMDB_LANGUAGE_KR } from '@/contants';
 import { getImageUrl } from '@/utils/tmdbUtils';
 import { ToggleGroup, ToggleGroupItem } from '@radix-ui/react-toggle-group';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import useNavigateToContents from '@/hooks/usePathParams';
+import usePathParams from '@/hooks/usePathParams';
 import PosterImage from '@/components/PosterImage';
 import '@/styles/custom.css';
 import { useGetCreditQuery } from '@/hooks/query/useActor';
@@ -16,13 +15,11 @@ import clsx from 'clsx';
 
 export default function Detail() {
   const [mode, setMode] = useState('info');
-  const { movieId: movieIdParam } = useParams();
-  const movieId = Number(movieIdParam);
+  const { useNumberPathState } = usePathParams();
+  const [movieId, setPathParam] = useNumberPathState('movieId');
 
-  const credit = useGetCreditQuery(movieId!, { language: TMDB_LANGUAGE_KR });
-  const similar = useGetSimilarMovieQuery(movieId!, { language: TMDB_LANGUAGE_KR });
-
-  const { updatePathParam } = useNavigateToContents();
+  const credit = useGetCreditQuery(movieId, { language: TMDB_LANGUAGE_KR });
+  const similar = useGetSimilarMovieQuery(movieId, { language: TMDB_LANGUAGE_KR });
 
   const { loading } = useAuth();
 
@@ -33,7 +30,7 @@ export default function Detail() {
   return (
     <>
       {loading && <SpinnerPortal />}
-      <DetailHeader movieId={movieId!} />
+      <DetailHeader movieId={movieId} />
       <main className="px-36">
         {/* 토글버튼 */}
         <div className="pt-3 flex justify-center">
@@ -85,7 +82,7 @@ export default function Detail() {
             </div>
             <div className="py-5">
               <h2 className="font-semibold">사용자 리뷰</h2>
-              <Comments movieId={movieId!} />
+              <Comments movieId={movieId} />
             </div>
           </>
         )}
@@ -100,7 +97,7 @@ export default function Detail() {
                   key={movie.id}
                   className="w-52  flex flex-col"
                   onClick={() => {
-                    updatePathParam('/movie', movie.id);
+                    setPathParam(movie.id);
                   }}
                 >
                   <PosterImage posterPath={movie.poster_path} size="w500" />

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -16,7 +16,8 @@ import clsx from 'clsx';
 
 export default function Detail() {
   const [mode, setMode] = useState('info');
-  const { movieId } = useParams();
+  const { movieId: movieIdParam } = useParams();
+  const movieId = Number(movieIdParam);
 
   const credit = useGetCreditQuery(movieId!, { language: TMDB_LANGUAGE_KR });
   const similar = useGetSimilarMovieQuery(movieId!, { language: TMDB_LANGUAGE_KR });
@@ -84,7 +85,7 @@ export default function Detail() {
             </div>
             <div className="py-5">
               <h2 className="font-semibold">사용자 리뷰</h2>
-              <Comments movieId={Number(movieId!)} />
+              <Comments movieId={movieId!} />
             </div>
           </>
         )}

--- a/src/pages/Favorite/index.tsx
+++ b/src/pages/Favorite/index.tsx
@@ -1,0 +1,37 @@
+import { useGetFavoriteQuery, useDeleteFavoriteQuery } from '@/hooks/query/useFavorite';
+import PosterImage from '@/components/PosterImage';
+import { useAuth } from '@/context/AuthContext';
+
+const Favorite = () => {
+  const favorites = useGetFavoriteQuery();
+  const deleteCommnet = useDeleteFavoriteQuery();
+
+  const getUser = useAuth();
+  const userId = getUser.session?.user.id;
+
+  const onFavoriteDelete = (movieId: number | null) => {
+    if (!userId || !movieId) {
+      return;
+    }
+
+    deleteCommnet.mutate({ userId, movieId });
+  };
+
+  return (
+    <div>
+      Favorite
+      <ul className="flex">
+        {favorites.data?.map((favorite) => (
+          <li key={favorite.id}>
+            {favorite.title}
+            <div className="w-40" onClick={() => onFavoriteDelete(favorite.movie_id)}>
+              <PosterImage posterPath={favorite.img_url} size={'w500'} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Favorite;

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -1,26 +1,24 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useGenreSearchMoviesQuery, useKeywordSearchMoviesQuery } from '@/hooks/query/useMovie';
 import { Movie } from '@/types/movie';
 import { TMDB_LANGUAGE_KR } from '@/contants';
 import ToggleButtons from '@/pages/Search/components/ToggleButtons';
 import useUrlParams from '@/hooks/useUrlParams';
-import useNavigateToContents from '@/hooks/usePathParams';
+import usePathParams from '@/hooks/usePathParams';
 import PosterImage from '@/components/PosterImage';
 
 const Search = () => {
-  const { getSearchParam, updateSearchParams } = useUrlParams();
-  const searchKeyword = getSearchParam('query');
-  const searchGenre = getSearchParam('with_genres');
+  const { useStringQueryState } = useUrlParams();
+  const [searchKeyword] = useStringQueryState('query');
+  const [genreParam, setGenreParam] = useStringQueryState('with_genres');
 
-  const { updatePathParam } = useNavigateToContents();
+  const { updatePathParam } = usePathParams();
 
-  const initialGenres = searchGenre?.split(',') || [];
+  const initialGenres = genreParam ? genreParam.split(',') : [];
   const [selectedGenres, setSelectedGenres] = useState<string[]>(initialGenres);
 
-  const selectedGenresToString = selectedGenres.join(',');
-
   useEffect(() => {
-    updateSearchParams({ with_genres: selectedGenresToString });
+    setGenreParam(selectedGenres.join(','));
   }, [selectedGenres]);
 
   // 장르 필터 > 장르 api만 / 키워드 필터 > 키워드 api만 / 장르+키워드 필터 > 키워드 api만
@@ -32,9 +30,9 @@ const Search = () => {
     {
       language: TMDB_LANGUAGE_KR,
       page: 1,
-      with_genres: selectedGenresToString,
+      with_genres: genreParam,
     },
-    isGenreFiltered && !!selectedGenresToString, // 빈 string이면 api 호출X
+    isGenreFiltered && !!genreParam, // 빈 string이면 api 호출X
   );
 
   // 키워드 필터

--- a/src/types/favorite.ts
+++ b/src/types/favorite.ts
@@ -1,0 +1,19 @@
+/** 즐겨찾기 데이터 타입 */
+export type FavoriteData = {
+  /** 영화 포스터 이미지 URL */
+  img_url: string;
+  /** TMDB 영화 ID */
+  movie_id: number;
+  /** 영화 제목 */
+  title: string;
+  /** 사용자 ID */
+  user_id: string;
+};
+
+/** 즐겨찾기 검색 매개변수 타입 */
+export type FavoriteSearchParams = {
+  /** 검색할 영화 ID */
+  movieId: number;
+  /** 검색할 사용자 ID */
+  userId: string;
+};


### PR DESCRIPTION
## ✅ 구현 내용
**1. 패스,쿼리 파라미터를 상태처럼 관리하는 훅 구현으로 DX 향상 (nuqs원리를 차용)**
- 파라미터를 상태처럼 관리
    - 기존 : 기존에는 useParams()로 직접 값을 가져와야 했음. 조회/수정 로직이 따로 존재
    - 개선 : 파라미터를 useState처럼 쉽게 읽고 업데이트할 수 있음 
    
- 타입 변환
    - 기존 : useParams로 조회한 id값을 string → number로 변환하는 작업을 컴포넌트마다 직접 처리해야 됐음.
    - 개선 : 패스 파라미터를 hook에서 조회하여 number로 전환하여 반환됨. 사용하는 쪽에서 타입변경 처리할 필요 없어짐.
    
<br/>

**2. 즐겨찾기 기능 구현 (조회,추가,삭제)**
- supanase 테이블 연동하여 사용자별 즐겨찾기 기능 추가
 
 
<img width="555" alt="image" src="https://github.com/user-attachments/assets/212c56f1-9418-4c34-85a6-8200d1ffdff7" />
