### PR TITLE
Feat/Suspense를 활용한 세션 로딩, 경로 가드처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import Layout from '@/components/Layout';
 import Home from '@/pages/Home';
@@ -6,8 +7,13 @@ import NotFound from '@/pages/NotFound';
 import Search from '@/pages/Search';
 import Signup from '@/pages/Signup';
 import Login from '@/pages/Login';
-import { AuthContextProvider } from '@/context/AuthContext';
+import { AuthContextProvider, useAuth } from '@/context/AuthContext';
 import Favorite from '@/pages/Favorite';
+
+const GuardRouter = ({ children }: { children: React.ReactNode }) => {
+  const { session } = useAuth();
+  return session ? <Navigate to="/movie" replace /> : children;
+};
 
 const router = createBrowserRouter([
   {
@@ -19,8 +25,22 @@ const router = createBrowserRouter([
       { path: 'movie/:movieId', element: <Detail /> },
       { path: 'search', element: <Search /> },
       { path: 'favorite', element: <Favorite /> },
-      { path: 'login', element: <Login /> },
-      { path: 'signup', element: <Signup /> },
+      {
+        path: 'login',
+        element: (
+          <GuardRouter>
+            <Login />
+          </GuardRouter>
+        ),
+      },
+      {
+        path: 'signup',
+        element: (
+          <GuardRouter>
+            <Signup />
+          </GuardRouter>
+        ),
+      },
     ],
   },
   { path: '*', element: <NotFound /> },
@@ -29,7 +49,7 @@ const router = createBrowserRouter([
 function App() {
   return (
     <AuthContextProvider>
-      <RouterProvider router={router} />;
+      <RouterProvider router={router} />
     </AuthContextProvider>
   );
 }

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -8,8 +8,6 @@ import PosterImage from '@/components/PosterImage';
 import '@/styles/custom.css';
 import { useGetCreditQuery } from '@/hooks/query/useActor';
 import DetailHeader from '@/pages/Detail/components/DetailHeader';
-import { useAuth } from '@/context/AuthContext';
-import SpinnerPortal from '@/components/Spinner';
 import Comments from '@/pages/Detail/components/Comments';
 import clsx from 'clsx';
 
@@ -21,15 +19,12 @@ export default function Detail() {
   const credit = useGetCreditQuery(movieId, { language: TMDB_LANGUAGE_KR });
   const similar = useGetSimilarMovieQuery(movieId, { language: TMDB_LANGUAGE_KR });
 
-  const { loading } = useAuth();
-
   useEffect(() => {
     setMode('info');
   }, [movieId]);
 
   return (
     <>
-      {loading && <SpinnerPortal />}
       <DetailHeader movieId={movieId} />
       <main className="px-36">
         {/* 토글버튼 */}


### PR DESCRIPTION
## 구현 내용
1. 세션 유효시 경로 가드처리
 : 로그인 후, 로그인/회원가입 창 진입시 홈화면으로 리다이렉트 처리

2. 세션 여부 확인 비동기 처리 중, suspense 활용한 로딩처리
 : `supabase.auth.getSession()`의 초기 세션 확인시,  `suspense`를 활용하여 로딩 처리
 :  기존 ) 각 컴포넌트에서 세션 확인
 : 개선 ) 새로고침시 앱 전체에서 세션 유효여부를 확인

3. `useAuth`가 `AuthContextProvider` 내부에서만 사용되도록 에러 메시지 추가  


## 기타
- 로그인 후 로그인창 진입시 : 스피너 로딩 → 로그인창 잠깐 출력 후 → 홈화면 전환되는 문제 발생